### PR TITLE
Make ansible-lint happy

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,3 +1,3 @@
 - name: Reload systemd
-  systemd:
+  ansible.builtin.systemd:
     daemon_reload: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,7 @@
 ---
-- block:
-
+- name: Create timer and service units
+  when: timers is defined
+  block:
     - name: Failing when timer_command is undefined
       fail:
           msg: Varible timer_command is not defined
@@ -37,4 +38,3 @@
           scope: "{{ systemd_scope | default('system') }}"
       with_dict: "{{ timers }}"
 
-  when: timers is defined

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -14,7 +14,7 @@
         dest: "{{ systemd_base_path | default('/etc/systemd/system') }}/{{ item.key }}.service"
         owner: "{{ item.value.timer_user | default('root') }}"
         group: "{{ item.value.timer_user | default('root') }}"
-        mode: 0644
+        mode: "0644"
       with_dict: "{{ timers }}"
       notify: Reload systemd
 
@@ -24,7 +24,7 @@
         dest: "{{ systemd_base_path | default('/etc/systemd/system') }}/{{ item.key }}.timer"
         owner: "{{ item.value.timer_user | default('root') }}"
         group: "{{ item.value.timer_user | default('root') }}"
-        mode: 0644
+        mode: "0644"
       with_dict: "{{ timers }}"
       notify: Reload systemd
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,37 +4,36 @@
   block:
     - name: Failing when timer_command is undefined
       ansible.builtin.fail:
-          msg: Varible timer_command is not defined
+        msg: Varible timer_command is not defined
       when: item.value.timer_command is undefined
       with_dict: "{{ timers }}"
 
     - name: Uploading service file
       ansible.builtin.template:
-          src: service.j2
-          dest: "{{ systemd_base_path | default('/etc/systemd/system') }}/{{ item.key }}.service"
-          owner: "{{ item.value.timer_user | default('root') }}"
-          group: "{{ item.value.timer_user | default('root') }}"
-          mode: 0644
+        src: service.j2
+        dest: "{{ systemd_base_path | default('/etc/systemd/system') }}/{{ item.key }}.service"
+        owner: "{{ item.value.timer_user | default('root') }}"
+        group: "{{ item.value.timer_user | default('root') }}"
+        mode: 0644
       with_dict: "{{ timers }}"
       notify: Reload systemd
 
     - name: Uploading timer file
       ansible.builtin.template:
-          src: timer.j2
-          dest: "{{ systemd_base_path | default('/etc/systemd/system') }}/{{ item.key }}.timer"
-          owner: "{{ item.value.timer_user | default('root') }}"
-          group: "{{ item.value.timer_user | default('root') }}"
-          mode: 0644
+        src: timer.j2
+        dest: "{{ systemd_base_path | default('/etc/systemd/system') }}/{{ item.key }}.timer"
+        owner: "{{ item.value.timer_user | default('root') }}"
+        group: "{{ item.value.timer_user | default('root') }}"
+        mode: 0644
       with_dict: "{{ timers }}"
       notify: Reload systemd
 
     - name: Enabling timers
       ansible.builtin.systemd:
-          name: "{{ item.key }}.timer"
-          state: restarted
-          enabled: true
-          masked: false
-          daemon_reload: true
-          scope: "{{ systemd_scope | default('system') }}"
+        name: "{{ item.key }}.timer"
+        state: restarted
+        enabled: true
+        masked: false
+        daemon_reload: true
+        scope: "{{ systemd_scope | default('system') }}"
       with_dict: "{{ timers }}"
-

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,13 +3,13 @@
   when: timers is defined
   block:
     - name: Failing when timer_command is undefined
-      fail:
+      ansible.builtin.fail:
           msg: Varible timer_command is not defined
       when: item.value.timer_command is undefined
       with_dict: "{{ timers }}"
 
     - name: Uploading service file
-      template:
+      ansible.builtin.template:
           src: service.j2
           dest: "{{ systemd_base_path | default('/etc/systemd/system') }}/{{ item.key }}.service"
           owner: "{{ item.value.timer_user | default('root') }}"
@@ -19,7 +19,7 @@
       notify: Reload systemd
 
     - name: Uploading timer file
-      template:
+      ansible.builtin.template:
           src: timer.j2
           dest: "{{ systemd_base_path | default('/etc/systemd/system') }}/{{ item.key }}.timer"
           owner: "{{ item.value.timer_user | default('root') }}"
@@ -29,7 +29,7 @@
       notify: Reload systemd
 
     - name: Enabling timers
-      systemd:
+      ansible.builtin.systemd:
           name: "{{ item.key }}.timer"
           state: restarted
           enabled: true


### PR DESCRIPTION
Hi!

I've gone through the non-`meta`-related errors `ansible-lint` was throwing and fixed them.

Before:
```
$ ansible-lint
WARNING  Listing 13 violation(s) that are fatal
fqcn[action-core]: Use FQCN for builtin module actions (systemd).
handlers/main.yml:1 Use `ansible.builtin.systemd` or `ansible.legacy.systemd` instead.

key-order[task]: You can improve the task key order to: when, block
tasks/main.yml:2 Task/Handler: block/always/rescue

name[missing]: All tasks should be named.
tasks/main.yml:2 Task/Handler: block/always/rescue

fqcn[action-core]: Use FQCN for builtin module actions (fail).
tasks/main.yml:4 Use `ansible.builtin.fail` or `ansible.legacy.fail` instead.

yaml[indentation]: Wrong indentation: expected 8 but found 10
tasks/main.yml:6

fqcn[action-core]: Use FQCN for builtin module actions (template).
tasks/main.yml:10 Use `ansible.builtin.template` or `ansible.legacy.template` instead.

yaml[indentation]: Wrong indentation: expected 8 but found 10
tasks/main.yml:12

yaml[octal-values]: Forbidden implicit octal value "0644"
tasks/main.yml:16

fqcn[action-core]: Use FQCN for builtin module actions (template).
tasks/main.yml:20 Use `ansible.builtin.template` or `ansible.legacy.template` instead.

yaml[indentation]: Wrong indentation: expected 8 but found 10
tasks/main.yml:22

yaml[octal-values]: Forbidden implicit octal value "0644"
tasks/main.yml:26

fqcn[action-core]: Use FQCN for builtin module actions (systemd).
tasks/main.yml:30 Use `ansible.builtin.systemd` or `ansible.legacy.systemd` instead.

yaml[indentation]: Wrong indentation: expected 8 but found 10
tasks/main.yml:32

Read documentation for instructions on how to ignore specific rule violations.

                  Rule Violation Summary
 count tag                profile    rule associated tags
     1 key-order[task]    basic      formatting
     1 name[missing]      basic      idiom
     4 yaml[indentation]  basic      formatting, yaml
     2 yaml[octal-values] basic      formatting, yaml
     5 fqcn[action-core]  production formatting

Failed: 13 failure(s), 0 warning(s) on 6 files. Last profile that met the validation criteria was 'min'.
```

After:
```
$ ansible-lint

Passed: 0 failure(s), 0 warning(s) on 6 files. Last profile that met the validation criteria was 'production'.
```