### PR TITLE
Make 'Enabling timers' task idempotent

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -30,10 +30,9 @@
     - name: Enabling timers
       systemd:
           name: "{{ item.key }}.timer"
-          state: restarted
+          state: started
           enabled: true
           masked: false
-          daemon_reload: true
           scope: "{{ systemd_scope | default('system') }}"
       with_dict: "{{ timers }}"
 


### PR DESCRIPTION
The `Enabling timers` task is always doing a `daemon-reload` and a timer restart despite the fact that the tasks creating the units notify the `Reload systemd` handler.

These two changes make the task idempotent when no changes are needed.